### PR TITLE
Add SLURM scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ First rule of fight club is we don't talk about fight club.
 ```
 module purge
 
-# Compilador base
+# Compiler
 module load gcc/12.2.0
 
 # MPI
 module load openmpi/4.1.6--gcc--12.2.0-cuda-12.2
 
-# NetCDF C y Fortran compilados con ese MPI + GCC
-module load netcdf-c/4.9.2--openmpi--4.1.6--gcc--12.2.0-spack0.22
+# NetCDF Fortran compile with MPI + GCC
 module load netcdf-fortran/4.6.1--openmpi--4.1.6--gcc--12.2.0-spack0.22
 ```

--- a/code/cpu_model.sh
+++ b/code/cpu_model.sh
@@ -18,8 +18,7 @@ module load gcc/12.2.0
 # MPI
 module load openmpi/4.1.6--gcc--12.2.0-cuda-12.2
 
-# NetCDF C y Fortran compile with MPI + GCC
-module load netcdf-c/4.9.2--openmpi--4.1.6--gcc--12.2.0-spack0.22
+# NetCDF Fortran compile with MPI + GCC
 module load netcdf-fortran/4.6.1--openmpi--4.1.6--gcc--12.2.0-spack0.22
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/code/gpu_model.sh
+++ b/code/gpu_model.sh
@@ -19,8 +19,7 @@ module load gcc/12.2.0
 # MPI
 module load openmpi/4.1.6--gcc--12.2.0-cuda-12.2
 
-# NetCDF C y Fortran compile with MPI + GCC
-module load netcdf-c/4.9.2--openmpi--4.1.6--gcc--12.2.0-spack0.22
+# NetCDF Fortran compile with MPI + GCC
 module load netcdf-fortran/4.6.1--openmpi--4.1.6--gcc--12.2.0-spack0.22
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK


### PR DESCRIPTION
This pull request introduces two new SLURM job submission scripts to the `code` directory, providing templates for running the 2D Euler Equations model on both CPU and GPU clusters. These scripts set up the necessary environment modules, resource allocations, and execution commands for efficient job scheduling and execution.

**New SLURM job scripts for cluster execution:**

* Added `cpu_model.sh` for submitting jobs to the DCGP CPU partition, including configuration for MPI, OpenMP, and NetCDF modules.
* Added `gpu_model.sh` for submitting jobs to the Booster GPU partition, with GPU resource allocation and similar environment setup as the CPU script.